### PR TITLE
Update class.modxRTEbridge.php

### DIFF
--- a/assets/plugins/tinymce4/class.modxRTEbridge.php
+++ b/assets/plugins/tinymce4/class.modxRTEbridge.php
@@ -29,6 +29,7 @@ class modxRTEbridge
     public $ajaxSecHash = array();              // Holds security-hashes
     private $mgrAction = null;
     protected $modx = null;
+    protected $gSettingsRows = null;
 
     /**
      * modxRTEbridge constructor.


### PR DESCRIPTION
В PHP 8.2 ругается на deprecated при инициализации новых  свойств в коде, как например в 118 строке: `$this->gSettingsRows = $settingsRows; `
Добавление свойства в класс убирает это ругательство.